### PR TITLE
Added the Nobara distro merch site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ https://postmarketos.org/merch/
 
 https://fedoraproject.org/wiki/Store
 
+**Nobara**
+
+https://nobara-project-merch-store.printify.me/products
+
 **Gentoo**
 
 https://www.gentoo.org/inside-gentoo/stores/


### PR DESCRIPTION
I added the link to the Nobara distro merch site. This URL is temporary according to Nobara's main site, so I'll keep an eye on when they get their permanent merch site running.